### PR TITLE
Adding User in admin panel bug fixed

### DIFF
--- a/gsoc/router.py
+++ b/gsoc/router.py
@@ -56,6 +56,8 @@ class DatabaseAppsRouter(object):
         """Make sure that apps only appear in the related database."""
         if app_label == 'cms' and model_name == 'pageuser':
             return 'auth_db' == db
+        elif app_label == 'contenttypes':
+            return True
         elif db in list(settings.DATABASE_APPS_MAPPING.values()):
             return settings.DATABASE_APPS_MAPPING.get(app_label) == db
         elif app_label in settings.DATABASE_APPS_MAPPING:

--- a/gsoc/router.py
+++ b/gsoc/router.py
@@ -1,4 +1,6 @@
 from django.conf import settings
+from cms.models import PageUser
+
 
 class DatabaseAppsRouter(object):
     """
@@ -15,13 +17,17 @@ class DatabaseAppsRouter(object):
 
     def db_for_read(self, model, **hints):
         """Point all read operations to the specific database."""
-        if model._meta.app_label in settings.DATABASE_APPS_MAPPING:
+        if model == PageUser:
+            return 'auth_db'
+        elif model._meta.app_label in settings.DATABASE_APPS_MAPPING:
             return settings.DATABASE_APPS_MAPPING[model._meta.app_label]
         return None
 
     def db_for_write(self, model, **hints):
         """Point all write operations to the specific database."""
-        if model._meta.app_label in settings.DATABASE_APPS_MAPPING:
+        if model == PageUser:
+            return 'auth_db'
+        elif model._meta.app_label in settings.DATABASE_APPS_MAPPING:
             return settings.DATABASE_APPS_MAPPING[model._meta.app_label]
         return None
 
@@ -38,8 +44,9 @@ class DatabaseAppsRouter(object):
 
     def allow_syncdb(self, db, model):
         """Make sure that apps only appear in the related database."""
-
-        if db in list(settings.DATABASE_APPS_MAPPING.values()):
+        if model == PageUser:
+            return 'auth_db'
+        elif db in list(settings.DATABASE_APPS_MAPPING.values()):
             return settings.DATABASE_APPS_MAPPING.get(model._meta.app_label) == db
         elif model._meta.app_label in settings.DATABASE_APPS_MAPPING:
             return False
@@ -47,8 +54,9 @@ class DatabaseAppsRouter(object):
 
     def allow_migrate(self, db, app_label, model_name=None, **hints):
         """Make sure that apps only appear in the related database."""
-
-        if db in list(settings.DATABASE_APPS_MAPPING.values()):
+        if app_label == 'cms' and model_name == 'pageuser':
+            return 'auth_db' == db
+        elif db in list(settings.DATABASE_APPS_MAPPING.values()):
             return settings.DATABASE_APPS_MAPPING.get(app_label) == db
         elif app_label in settings.DATABASE_APPS_MAPPING:
             return False

--- a/gsoc/router.py
+++ b/gsoc/router.py
@@ -58,6 +58,8 @@ class DatabaseAppsRouter(object):
             return 'auth_db' == db
         elif app_label == 'contenttypes':
             return True
+        elif app_label == 'auth' and model_name == 'permission':
+            return 'default'
         elif db in list(settings.DATABASE_APPS_MAPPING.values()):
             return settings.DATABASE_APPS_MAPPING.get(app_label) == db
         elif app_label in settings.DATABASE_APPS_MAPPING:

--- a/gsoc/settings.py
+++ b/gsoc/settings.py
@@ -214,10 +214,11 @@ DATABASES = {
 }
 
 DATABASE_APPS_MAPPING = {
-    'gsoc': 'default',
+    'gsoc': 'auth_db',
     'auth': 'auth_db',
     'admin': 'auth_db',
-    'sessions': 'auth_db'
+    'sessions': 'auth_db',
+    'contenttypes': 'auth_db'
 }
 
 DATABASE_ROUTERS = ['gsoc.router.DatabaseAppsRouter']

--- a/gsoc/settings.py
+++ b/gsoc/settings.py
@@ -214,11 +214,10 @@ DATABASES = {
 }
 
 DATABASE_APPS_MAPPING = {
-    'gsoc': 'auth_db',
+    'gsoc': 'default',
     'auth': 'auth_db',
     'admin': 'auth_db',
     'sessions': 'auth_db',
-    'contenttypes': 'auth_db'
 }
 
 DATABASE_ROUTERS = ['gsoc.router.DatabaseAppsRouter']

--- a/gsoc/settings.py
+++ b/gsoc/settings.py
@@ -214,7 +214,6 @@ DATABASES = {
 }
 
 DATABASE_APPS_MAPPING = {
-    'gsoc': 'default',
     'auth': 'auth_db',
     'admin': 'auth_db',
     'sessions': 'auth_db',


### PR DESCRIPTION
Fixes #21
3 minor changes:
1. There is one signal called when new user is created through admin panel which can be found in:
`cms.signals.permissions.py: 8`
And in that function, PageUser model is used. Now when signal is called then it creates a new row in default database rather than using users.db and if we pass database name (auth_db) through router then `cms_pageuser` table will be missing. So for that we needed `cms_pageuser` table in our `users.db` to make it work. Hence I modified router.py to make it work. 
Here PageUser model keeps track of which user created another user at that time.
Now to see it in action, delete `users.db` and create a fresh one.

2. During fresh migration process, there was another error:
`no such table: django_content_type`
Which needs to be there in `users.db` so I added `contenttypes` in database mapping. Not sure if needed in projects.db too.
3. Gsoc year and suborg is shifted to users.db

@botanicvelious Can you please check