### PR TITLE
Add role field to UserProfile

### DIFF
--- a/gsoc/forms.py
+++ b/gsoc/forms.py
@@ -5,9 +5,5 @@ from .models import UserProfile
 
 class UserProfileForm(ModelForm):
     class Meta:
-        fields = ('suborg_full_name', 'gsoc_year')
+        fields = ('role', 'suborg_full_name', 'gsoc_year')
         model = UserProfile
-        widgets = {
-            'suborg_full_name': CheckboxSelectMultiple(),
-            'gsoc_year': CheckboxSelectMultiple()
-        }

--- a/gsoc/models.py
+++ b/gsoc/models.py
@@ -35,26 +35,14 @@ class GsocYear(models.Model):
 
 
 class UserProfile(models.Model):
-    user = models.OneToOneField(User, on_delete=models.CASCADE)
-    gsoc_year = models.ManyToManyField(GsocYear, blank=True)
-    suborg_full_name = models.ManyToManyField(SubOrg, blank=True)
+    ROLES = (
+        (0, 'Others'),
+        (1, 'Suborg Admin'),
+        (2, 'Mentor'),
+        (3, 'Student')
+    )
 
-
-def suborg_full_name(self):
-    try:
-        user_profile = UserProfile.objects.get(user=self.id)
-        return user_profile.suborg_full_name.all()
-    except SubOrg.DoesNotExist:
-        return None
-
-
-def gsoc_year(self):
-    try:
-        user_profile = UserProfile.objects.get(user=self.id)
-        return user_profile.gsoc_year.all()
-    except GsocYear.DoesNotExist:
-        return None
-
-
-auth.models.User.add_to_class('suborg_full_name', suborg_full_name)
-auth.models.User.add_to_class('gsoc_year', gsoc_year)
+    user = models.ForeignKey(User, on_delete=models.CASCADE)
+    role = models.IntegerField(name='role', choices=ROLES, default=0)
+    gsoc_year = models.ForeignKey(GsocYear, on_delete=models.CASCADE, null=True, blank=False)
+    suborg_full_name = models.ForeignKey(SubOrg, on_delete=models.CASCADE, null=True, blank=False)


### PR DESCRIPTION
# Description

This adds a `role` field to `UserProfile` to denote the role of the user. And it also changes `user` from a `OneToOneField` to `ForeignField`. This basically means that one user can have multiple `UserProfile`s, each one referring to her association with a particular GSoC (either as a student, a mentor, or an suborg-admin).

All the changes reflect on the admin panel too.

Fixes #54 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Added a new `user` and then added multiple `UserProfile`s for it using admin panel.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have not added a commit to any .db files as part of my pull request
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
