### PR TITLE
Student blog setup

### DIFF
--- a/gsoc/admin.py
+++ b/gsoc/admin.py
@@ -1,4 +1,4 @@
-from .models import UserProfile, UserDetails, Scheduler
+from .models import UserProfile, RegLink, UserDetails, Scheduler
 from .forms import UserProfileForm, UserDetailsForm
 
 from django.contrib.auth.models import User
@@ -6,8 +6,8 @@ from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin as DjangoUserAdmin
 from django.utils.translation import ugettext_lazy as _
 from django.utils import timezone
-from .models import UserProfile, RegLink
-from .forms import UserProfileForm
+from django.core.exceptions import PermissionDenied
+
 from aldryn_people.models import Person
 from aldryn_newsblog.admin import ArticleAdmin
 from aldryn_newsblog.models import Article
@@ -59,12 +59,12 @@ def article_get_form():
                         'featured_image',
                         'lead_in',
                     )}),
-                (_('Meta Options'),
-                 {'classes': ('collapse',),
-                  'fields':()}),
+                # (_('Meta Options'),
+                #  {'classes': ('collapse',),
+                #   'fields':()}),
                 (_('Advanced Settings'),
                  {'classes': ('collapse',),
-                  'fields': ()}),
+                  'fields': ('app_config',)}),
             )
             self.readonly_fields = (
                 'author',
@@ -97,12 +97,12 @@ def Article_add_view(self, request, *args, **kwargs):
         except Person.DoesNotExist:
             person = Person.objects.create(user=request.user)
             post_data['author'] = person.pk
-        try:
-            data['app_config'] = str(NewsBlogConfig.objects.first().pk)
-            post_data['app_config'] = str(NewsBlogConfig.objects.first().pk)
-            print(data['app_config'])
-        except NewsBlogConfig.DoesNotExist:
-            pass
+        # try:
+        #     data['app_config'] = str(NewsBlogConfig.objects.first().pk)
+        #     post_data['app_config'] = str(NewsBlogConfig.objects.first().pk)
+        #     print(data['app_config'])
+        # except NewsBlogConfig.DoesNotExist:
+        #     pass
         post_data['publishing_date_0'] = f'{str(timenow.year)}-{str(timenow.month).zfill(2)}-{str(timenow.day).zfill(2)}'
         post_data['initial-publishing_date_0'] = f'{str(timenow.year)}-{str(timenow.month).zfill(2)}-{str(timenow.day).zfill(2)}'
         post_data['publishing_date_1'] = f'{str(timenow.hour).zfill(2)}:{str(timenow.minute).zfill(2)}:{str(timenow.second).zfill(2)}'
@@ -120,12 +120,67 @@ def Article_add_view(self, request, *args, **kwargs):
     request.POST = post_data
     return super(ArticleAdmin, self).add_view(request, *args, **kwargs)
 
+def Article_save_model(self, request, obj, form, change):
+    # checks whether user has add permission in the current
+    # section before adding to the blog
+    user = request.user
+    has_add_perm = False
+    if user.is_superuser:
+        has_add_perm = True
+    else:
+        userprofiles = user.userprofile_set.all()
+        for profile in userprofiles:
+            if profile.app_config == obj.app_config:
+                has_add_perm = True
+                break
+
+    if has_add_perm:
+        super(ArticleAdmin, self).save_model(request, obj, form, change)
+    else:
+        raise PermissionDenied()
+
+def Article_delete_model(self, request, obj):
+    # checks whether user has delete permission in the current
+    # section before adding to the blog
+    user = request.user
+    has_delete_perm = False
+    if user.is_superuser:
+        has_delete_perm = True
+    else:
+        userprofiles = user.userprofile_set.all()
+        for profile in userprofiles:
+            if profile.app_config == obj.app_config:
+                has_delete_perm = True
+                break
+
+    if has_delete_perm:
+        super(ArticleAdmin, self).delete_model(request, obj, form, change)
+    else:
+        raise PermissionDenied()
+
+def Article_get_queryset(self, request):
+    user = request.user
+    qs = Article.objects.all()
+
+    if user.is_superuser:
+        return qs
+    else:
+        userprofiles = user.userprofile_set.all()
+        app_configs = []
+        for profile in userprofiles:
+            app_configs.append(profile.app_config)
+        qs = qs.filter(app_config__in=app_configs)
+        print(qs)
+        return qs
+
+ArticleAdmin.save_model = Article_save_model
+ArticleAdmin.delete_model = Article_delete_model
+ArticleAdmin.get_queryset = Article_get_queryset
 ArticleAdmin.get_form = article_get_form()
 ArticleAdmin.add_view = Article_add_view
 
 admin.site.unregister(Article)
 admin.site.register(Article, ArticleAdmin)
-
 
 
 class RegLinkAdmin(admin.ModelAdmin):
@@ -156,7 +211,6 @@ class RegLinkAdmin(admin.ModelAdmin):
          )
         else:
             return self.readonly_fields
-
 
 admin.site.register(RegLink, RegLinkAdmin)
 

--- a/gsoc/cms_toolbars.py
+++ b/gsoc/cms_toolbars.py
@@ -7,13 +7,18 @@ from cms.cms_toolbars import (
     SHORTCUTS_BREAK,
     CLIPBOARD_BREAK
 )
-
-from django.contrib.sites.models import Site
-from django.utils.translation import ugettext_lazy as _
-
 from cms.utils.conf import get_cms_setting
 from cms.utils.urlutils import admin_reverse
 
+from django.contrib.sites.models import Site
+from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import get_language_from_request
+
+from aldryn_translation_tools.utils import (
+    get_admin_url, get_object_from_request,
+)
+from aldryn_newsblog.models import Article
+from aldryn_newsblog.cms_toolbars import NewsBlogToolbar
 
 def add_admin_menu(self):
     if not self._admin_menu:
@@ -67,3 +72,92 @@ def add_admin_menu(self):
         self.add_logout_button(self._admin_menu)
 
 BasicToolbar.add_admin_menu = add_admin_menu
+
+
+def populate(self):
+    config = self._NewsBlogToolbar__get_newsblog_config()
+    if not config:
+        # Do nothing if there is no NewsBlog app_config to work with
+        return
+
+    user = getattr(self.request, 'user', None)
+    try:
+        view_name = self.request.resolver_match.view_name
+    except AttributeError:
+        view_name = None
+
+    if user and view_name:
+        language = get_language_from_request(self.request, check_path=True)
+
+        # If we're on an Article detail page, then get the article
+        if view_name == '{0}:article-detail'.format(config.namespace):
+            article = get_object_from_request(Article, self.request)
+        else:
+            article = None
+
+        menu = self.toolbar.get_or_create_menu('newsblog-app',
+                                                config.get_app_title())
+
+        change_config_perm = user.has_perm(
+            'aldryn_newsblog.change_newsblogconfig')
+        add_config_perm = user.has_perm(
+            'aldryn_newsblog.add_newsblogconfig')
+        config_perms = [change_config_perm, add_config_perm]
+
+        add_article_perm = False
+        userprofiles = user.userprofile_set.all()
+        for profile in userprofiles:
+            if profile.app_config == config:
+                add_article_perm = True
+                break
+
+        delete_article_perm = user.is_superuser if article else False
+        change_article_perm = user.is_superuser
+
+        article_perms = [change_article_perm, add_article_perm,
+                            delete_article_perm, ]
+
+        if change_config_perm:
+            url_args = {}
+            if language:
+                url_args = {'language': language, }
+            url = get_admin_url('aldryn_newsblog_newsblogconfig_change',
+                                [config.pk, ], **url_args)
+            menu.add_modal_item(_('Configure addon'), url=url)
+
+        if any(config_perms) and any(article_perms):
+            menu.add_break()
+
+        if change_article_perm:
+            url_args = {}
+            if config:
+                url_args = {'app_config__id__exact': config.pk}
+            url = get_admin_url('aldryn_newsblog_article_changelist',
+                                **url_args)
+            menu.add_sideframe_item(_('Article list'), url=url)
+
+        if add_article_perm:
+            url_args = {'app_config': config.pk, 'owner': user.pk, }
+            if language:
+                url_args.update({'language': language, })
+            url = get_admin_url('aldryn_newsblog_article_add', **url_args)
+            menu.add_modal_item(_('Add new article'), url=url)
+
+        if change_article_perm and article:
+            url_args = {}
+            if language:
+                url_args = {'language': language, }
+            url = get_admin_url('aldryn_newsblog_article_change',
+                                [article.pk, ], **url_args)
+            menu.add_modal_item(_('Edit this article'), url=url,
+                                active=True)
+
+        if delete_article_perm and article:
+            redirect_url = self.get_on_delete_redirect_url(
+                article, language=language)
+            url = get_admin_url('aldryn_newsblog_article_delete',
+                                [article.pk, ])
+            menu.add_modal_item(_('Delete this article'), url=url,
+                                on_close=redirect_url)
+
+NewsBlogToolbar.populate = populate

--- a/gsoc/cms_toolbars.py
+++ b/gsoc/cms_toolbars.py
@@ -105,14 +105,15 @@ def populate(self):
         config_perms = [change_config_perm, add_config_perm]
 
         add_article_perm = False
+        change_article_perm = False
         userprofiles = user.userprofile_set.all()
         for profile in userprofiles:
             if profile.app_config == config:
                 add_article_perm = True
+                change_article_perm = True
                 break
 
         delete_article_perm = user.is_superuser if article else False
-        change_article_perm = user.is_superuser
 
         article_perms = [change_article_perm, add_article_perm,
                             delete_article_perm, ]

--- a/gsoc/cms_wizards.py
+++ b/gsoc/cms_wizards.py
@@ -1,0 +1,78 @@
+from django import forms
+from django.utils.translation import ugettext_lazy as _
+
+from cms.api import add_plugin
+from cms.utils import permissions
+
+from djangocms_text_ckeditor.html import clean_html
+
+from aldryn_newsblog.cms_appconfig import NewsBlogConfig
+from aldryn_newsblog.cms_wizards import (
+    NewsBlogArticleWizard,
+    CreateNewsBlogArticleForm,
+    get_published_app_configs
+)
+
+
+def user_has_add_permission(self, user, **kwargs):
+    """
+    Return True if the current user has permission to add an article.
+    :param user: The current user
+    :param kwargs: Ignored here
+    :return: True if user has add permission, else False
+    """
+    # No one can create an Article, if there is no app_config yet.
+    num_configs = get_published_app_configs()
+    if not num_configs:
+        return False
+
+    # Ensure user has permission to create articles.
+    if user.is_superuser or user.student_profile() is not None:
+        return True
+
+    # By default, no permission.
+    return False
+
+NewsBlogArticleWizard.user_has_add_permission = user_has_add_permission
+
+
+CreateNewsBlogArticleForm.Meta.fields = ['title']
+
+def __init__(self, **kwargs):
+    super(CreateNewsBlogArticleForm, self).__init__(**kwargs)
+
+    # If there's only 1 (or zero) app_configs, don't bother show the
+    # app_config choice field, we'll choose the option for the user.
+    app_configs = get_published_app_configs()
+
+    userprofiles = self.user.userprofile_set.all()
+    app_config_choices = []
+    for profile in userprofiles:
+        app_config_choices.append((profile.app_config.pk, profile.app_config.get_app_title()))
+    
+    self.fields['app_config'] = forms.ChoiceField(
+        label=_('Section'),
+        required=True,
+        choices=app_config_choices
+    )
+
+def save(self, commit=True):
+    article = super(CreateNewsBlogArticleForm, self).save(commit=False)
+    article.owner = self.user
+    article.app_config = NewsBlogConfig.objects.filter(pk=self.cleaned_data['app_config']).first()
+    article.save()
+
+    # If 'content' field has value, create a TextPlugin with same and add it to the PlaceholderField
+    content = clean_html(self.cleaned_data.get('content', ''), False)
+    if content and permissions.has_plugin_permission(self.user, 'TextPlugin', 'add'):
+        add_plugin(
+            placeholder=article.content,
+            plugin_type='TextPlugin',
+            language=self.language_code,
+            body=content,
+        )
+
+    return article
+
+CreateNewsBlogArticleForm.__init__ = __init__
+CreateNewsBlogArticleForm.save = save

--- a/gsoc/forms.py
+++ b/gsoc/forms.py
@@ -1,12 +1,16 @@
 from .models import UserProfile, UserDetails
 
-from django.forms import ModelForm, CheckboxSelectMultiple
+from django.forms import ModelForm, CheckboxSelectMultiple, Select
 
 
 class UserProfileForm(ModelForm):
     class Meta:
         model = UserProfile
         fields = ('role', 'suborg_full_name', 'gsoc_year', 'accepted_proposal_pdf', 'app_config')
+        widgets = {
+            'app_config': Select(),
+        }
+
 
 
 class ProposalUploadForm(ModelForm):

--- a/gsoc/forms.py
+++ b/gsoc/forms.py
@@ -6,7 +6,7 @@ from django.forms import ModelForm, CheckboxSelectMultiple
 class UserProfileForm(ModelForm):
     class Meta:
         model = UserProfile
-        fields = ('role', 'suborg_full_name', 'gsoc_year', 'accepted_proposal_pdf')
+        fields = ('role', 'suborg_full_name', 'gsoc_year', 'accepted_proposal_pdf', 'app_config')
 
 
 class ProposalUploadForm(ModelForm):

--- a/gsoc/models.py
+++ b/gsoc/models.py
@@ -13,6 +13,9 @@ from django.core.validators import validate_email
 from django.utils import timezone
 from django.shortcuts import reverse
 
+from aldryn_apphooks_config.fields import AppHookConfigField
+from aldryn_newsblog.cms_appconfig import NewsBlogConfig
+
 import phonenumbers
 from phonenumbers.phonenumbermatcher import PhoneNumberMatcher
 
@@ -44,6 +47,8 @@ class UserProfile(models.Model):
     gsoc_year = models.ForeignKey(GsocYear, on_delete=models.CASCADE, null=True, blank=False)
     suborg_full_name = models.ForeignKey(SubOrg, on_delete=models.CASCADE, null=True, blank=False)
     accepted_proposal_pdf = models.FileField(blank=True, null=True)
+    app_config = AppHookConfigField(NewsBlogConfig, verbose_name=_('Section'), blank=True, null=True)
+
 
 def has_proposal(self):
     try:
@@ -197,7 +202,6 @@ class ProposalTextValidator:
 
 
 validate_proposal_text = ProposalTextValidator()
-
 
 
 def gen_uuid_str():


### PR DESCRIPTION
# Description

Fixes #35 

This PR brings about the following changes
- Every `UserProfile` now also has a `NewsBlogSection` linked to them. That is basically the blog of the student.
- In the admin panel for a student, only the `Article`s that belong to them are displayed.
- Only that student can add/edit/change/delete the `Article`s in the corresponding `NewsBlogSection`. They can't change any `Article` in someone else's `NewsBlogSection`.
- The toolbar gets populated with options of adding/changing/editing/deleting depending upon whether they actually have the permission to do so.
- The wizard only shows the the options of the sections which belong to the current user and disables the create button if user is not a student or superuser.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have not added a commit to any .db files as part of my pull request
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules