### PR TITLE
Fix typo and minor bug

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -20,7 +20,7 @@ You can then access the site with the login bar with http://127.0.0.1:8000/en/?e
 ```
 Default user/pass is `admin` for the superuser
 
-Default student user is `Test-Student1` pass `^vM7d5*wK2R77V'`
+Default student user is `Test-Student1` pass `^vM7d5*wK2R77V`
 ```
 ## Contributing
 Pull requests are welcome. For major changes, please open an issue first to discuss what you would like to change.

--- a/gsoc/cms_toolbars.py
+++ b/gsoc/cms_toolbars.py
@@ -1,18 +1,18 @@
-from cms.cms_toolbars import BasicToolbar
+from cms.cms_toolbars import (
+    BasicToolbar,
+    ADMIN_MENU_IDENTIFIER,
+    ADMINISTRATION_BREAK,
+    USER_SETTINGS_BREAK,
+    TOOLBAR_DISABLE_BREAK,
+    SHORTCUTS_BREAK,
+    CLIPBOARD_BREAK
+)
 
 from django.contrib.sites.models import Site
 from django.utils.translation import ugettext_lazy as _
 
 from cms.utils.conf import get_cms_setting
 from cms.utils.urlutils import admin_reverse
-
-
-# # Identifiers for search
-ADMIN_MENU_IDENTIFIER = 'admin-menu'
-ADMINISTRATION_BREAK = 'Administration Break'
-USER_SETTINGS_BREAK = 'User Settings Break'
-TOOLBAR_DISABLE_BREAK = 'Toolbar disable Break'
-SHORTCUTS_BREAK = 'Shortcuts Break'
 
 
 def add_admin_menu(self):


### PR DESCRIPTION
- Fixes minor typo in README.md
- Adds `CLIPBOARD_BREAK = 'Clipboard Break'` to cms_toolbars.py
