### PR TITLE
Defined Variable CLIPBOARD_BREAK

### DIFF
--- a/gsoc/cms_toolbars.py
+++ b/gsoc/cms_toolbars.py
@@ -13,7 +13,7 @@ ADMINISTRATION_BREAK = 'Administration Break'
 USER_SETTINGS_BREAK = 'User Settings Break'
 TOOLBAR_DISABLE_BREAK = 'Toolbar disable Break'
 SHORTCUTS_BREAK = 'Shortcuts Break'
-
+CLIPBOARD_BREAK = 'Clipboard Break'
 
 def add_admin_menu(self):
     if not self._admin_menu:


### PR DESCRIPTION
# Description

For Admin Page, On pressing **Edit** button on the nav bar, It throws error as described in #87 

Fixes #87 

## Type of change
Defined the variable CLIPBOARD_BREAK

Please delete options that are not relevant.

- [x] Bug fix (a non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
