### PR TITLE
Add hidden field to UserProfile model to hide users

### DIFF
--- a/gsoc/forms.py
+++ b/gsoc/forms.py
@@ -1,16 +1,22 @@
-from .models import UserProfile, UserDetails
+from .models import UserDetails, UserProfile
 
-from django.forms import ModelForm, CheckboxSelectMultiple, Select
+from django.forms import ModelForm, Select
 
 
 class UserProfileForm(ModelForm):
     class Meta:
         model = UserProfile
-        fields = ('role', 'suborg_full_name', 'gsoc_year', 'accepted_proposal_pdf', 'app_config')
+        fields = (
+            'role',
+            'suborg_full_name',
+            'gsoc_year',
+            'accepted_proposal_pdf',
+            'app_config',
+            'hidden'
+            )
         widgets = {
             'app_config': Select(),
-        }
-
+            }
 
 
 class ProposalUploadForm(ModelForm):


### PR DESCRIPTION
# Description

This adds the feature of hiding an user (mostly student) is he/she is discontinued from the GSoC program.

A UserProfile can be hid from the admin profile and all the UserProfiles can also be viewed from the admin panel where they can be filtered according to whether the UserProfile is hidden or not, and then can be marked `hidden=False` if necessary.

Fixes #116 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Checked using the admin panel

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have not added a commit to any .db files as part of my pull request
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
