### PR TITLE
Add email field to RegLink admin; alphabetically sort blogs

### DIFF
--- a/blogs_list/views.py
+++ b/blogs_list/views.py
@@ -42,6 +42,7 @@ def list_blogs(request):
                     })
 
         if flag:
+            blogset = sorted(blogset, key=lambda i: (i['title']))
             blogsets.append((year.gsoc_year, blogset))
 
     if not blogsets:

--- a/gsoc/admin.py
+++ b/gsoc/admin.py
@@ -234,7 +234,7 @@ class RegLinkAdmin(admin.ModelAdmin):
         'adduserlog',
         'has_scheduler'
         )
-    list_display = ('reglink_id', 'url', 'is_used', 'is_sent', 'created_at')
+    list_display = ('reglink_id', 'email', 'is_used', 'is_sent', 'created_at')
     list_filter = [
         'is_used',
         'created_at',


### PR DESCRIPTION
Fixes #171 
Also adds email to the `list_display` of RegLinkAdmin