### PR TITLE
No longer displays suborg applications menu choices for students, fixes #382 

### DIFF
--- a/gsoc/cms_toolbars.py
+++ b/gsoc/cms_toolbars.py
@@ -51,11 +51,6 @@ def add_admin_menu(self):
 
         user = getattr(self.request, "user", None)
 
-        if user:
-            user_profile = UserProfile.objects.filter(user=user)[0]
-            role = user_profile.get_role_display()
-            # role is 'Others', 'Suborg Admin', 'Mentor', or 'Student'
-
         # admin
         self._admin_menu.add_sideframe_item(
             _("Administration"), url=admin_reverse("index")
@@ -88,7 +83,7 @@ def add_admin_menu(self):
                 on_close=None,
             )
 
-        if user and role != 'Student':
+        if user and not user.is_current_year_student():
             self._admin_menu.add_link_item(
                 _("New Suborg Application"), reverse("suborg:register_suborg")
             )

--- a/gsoc/cms_toolbars.py
+++ b/gsoc/cms_toolbars.py
@@ -22,7 +22,7 @@ from aldryn_newsblog.cms_toolbars import NewsBlogToolbar
 
 from cms.models import Page
 
-from gsoc.models import ArticleReview
+from gsoc.models import ArticleReview, UserProfile
 
 
 def add_admin_menu(self):
@@ -50,6 +50,11 @@ def add_admin_menu(self):
                 )
 
         user = getattr(self.request, "user", None)
+
+        if user:
+            user_profile = UserProfile.objects.filter(user=user)[0]
+            role = user_profile.get_role_display()
+            # role is 'Others', 'Suborg Admin', 'Mentor', or 'Student'
 
         # admin
         self._admin_menu.add_sideframe_item(
@@ -83,7 +88,7 @@ def add_admin_menu(self):
                 on_close=None,
             )
 
-        if user:
+        if user and role != 'Student':
             self._admin_menu.add_link_item(
                 _("New Suborg Application"), reverse("suborg:register_suborg")
             )


### PR DESCRIPTION
This patch starts by querying the user's profile:
        if user:
            user_profile = UserProfile.objects.filter(user=user)[0]
            role = user_profile.get_role_display()

Then only adds the suborg administration menu items if role != 'Student'

The user's profile is almost certainly going to be useful for future menu customization.
