### PR TITLE
remove gsoc-admins@python.org from settings template

### DIFF
--- a/gsoc/management/commands/runcron.py
+++ b/gsoc/management/commands/runcron.py
@@ -83,7 +83,7 @@ class Command(BaseCommand):
                     builder.last_error = err
                     builder.save()
                     send_mail(
-                        settings.ADMINS,
+                        settings.ERROR_NOTIFY_ML,
                         "Exception on runcron build_items",
                         "cron_error.html",
                         {"message": err, "time": today},
@@ -118,7 +118,7 @@ class Command(BaseCommand):
             scheduler.last_error = err
             scheduler.save()
             send_mail(
-                settings.ADMINS,
+                settings.ERROR_NOTIFY_ML,
                 "Exception on runcron process_items",
                 "cron_error.html",
                 {"message": err, "time": today},

--- a/settings_local.py.template
+++ b/settings_local.py.template
@@ -40,7 +40,8 @@ EMAIL_PORT = 25
 REPLY_EMAIL = "gsoc-admins@python.org"
 
 # Admins
-ADMINS = (("GSoC Admins"))
+ADMINS = (("GSoC Admins", "gsoc-admins@python.org"))
+ERROR_NOTIFY_ML = ()
 
 # reCAPTCHA settings
 # update the `RECAPTCHA_PUBLIC_KEY` in `/static/js/recaptcha.js` manually

--- a/settings_local.py.template
+++ b/settings_local.py.template
@@ -40,7 +40,7 @@ EMAIL_PORT = 25
 REPLY_EMAIL = "gsoc-admins@python.org"
 
 # Admins
-ADMINS = (("GSoC Admins", "gsoc-admins@python.org"))
+ADMINS = (("GSoC Admins"))
 
 # reCAPTCHA settings
 # update the `RECAPTCHA_PUBLIC_KEY` in `/static/js/recaptcha.js` manually


### PR DESCRIPTION
# Description

Removed gsoc-admins@python.org from the list of emails that are notified on every website breakdown.

Fixes #406 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Since the email has been removed, the email won't be sent to the address on runtime failure.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have not added a commit to any .db files as part of my pull request
- [ ] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
