### PR TITLE
add feature to see added mentors by suborg-admin

### DIFF
--- a/suborg/templates/application_list.html
+++ b/suborg/templates/application_list.html
@@ -1,4 +1,5 @@
 {% extends CMS_TEMPLATE %}
+{% load dict_key %}
 
 {% block content %}
 <div class="content">
@@ -19,13 +20,22 @@
 				{% else %}
 					{{ application.gsoc_year }} {{ application.suborg_name }}
 				{% endif %}
-				
                 {% if application.accepted and gsoc_year == application.gsoc_year %}
-                     - Accepted, <a href="{% url 'suborg:add_mentor' application_id=application.id %}">Add Mentors</a>
+                    - Accepted,
+                    <br>
+                    <strong>Mentors:</strong>
+                    <ol>
+                    {% for mentor in mentors_list|dict_key:application.suborg.id %}
+                        <li>
+                            {{ mentor.user.username }}
+                        </li>
+                    {% endfor %}
+                    </ol>
+                    <a href="{% url 'suborg:add_mentor' application_id=application.id %}">Add Mentors</a>
                 {% elif gsoc_year == application.gsoc_year %}
                      - Not Accepted
                 {% endif %}
-            </li>
+            </li><br>
         {% endfor %}
     </ul>
     <p>

--- a/suborg/templatetags/dict_key.py
+++ b/suborg/templatetags/dict_key.py
@@ -1,0 +1,7 @@
+from django.template.defaultfilters import register
+
+
+@register.filter(name='dict_key')
+def dict_key(d, k):
+    '''Returns the given key from a dictionary.'''
+    return d[k]

--- a/suborg/views.py
+++ b/suborg/views.py
@@ -1,5 +1,5 @@
 from gsoc.forms import SubOrgApplicationForm
-from gsoc.models import GsocYear, SubOrgDetails, RegLink
+from gsoc.models import GsocYear, SubOrgDetails, RegLink, UserProfile
 
 from django.contrib.auth.models import User
 from django.contrib.auth import decorators
@@ -30,11 +30,18 @@ def home(request):
 @decorators.login_required
 def application_list(request):
     applications = SubOrgDetails.objects.filter(suborg_admin_email=request.user.email)
+    print(applications)
+    mentors_list = {}
+    for a in applications:
+        mentors_list[a.suborg.id] = UserProfile.objects.filter(role=2, suborg_full_name=a.suborg.id)
+    print(mentors_list)
+    # for a in applications:
+    #     mentors_list[a.id] = RegLink.objects.filter(user_suborg=a.id)
     gsoc_year = GsocYear.objects.first()
     if len(applications) == 0:
         return redirect(reverse("suborg:register_suborg"))
 
-    return render(request, "application_list.html", {"applications": applications, "gsoc_year": gsoc_year})
+    return render(request, "application_list.html", {"applications": applications, "gsoc_year": gsoc_year, "mentors_list": mentors_list})
 
 
 @decorators.login_required
@@ -138,7 +145,7 @@ def add_mentor(request, application_id):
         )
         return redirect(reverse("suborg:application_list"))
 
-    MentorFormSet = modelformset_factory(RegLink, fields=("email",), extra=4)
+    MentorFormSet = modelformset_factory(RegLink, fields=("email",))
 
     if request.method == "POST":
         formset = MentorFormSet(request.POST)

--- a/suborg/views.py
+++ b/suborg/views.py
@@ -30,13 +30,9 @@ def home(request):
 @decorators.login_required
 def application_list(request):
     applications = SubOrgDetails.objects.filter(suborg_admin_email=request.user.email)
-    print(applications)
     mentors_list = {}
     for a in applications:
         mentors_list[a.suborg.id] = UserProfile.objects.filter(role=2, suborg_full_name=a.suborg.id)
-    print(mentors_list)
-    # for a in applications:
-    #     mentors_list[a.id] = RegLink.objects.filter(user_suborg=a.id)
     gsoc_year = GsocYear.objects.first()
     if len(applications) == 0:
         return redirect(reverse("suborg:register_suborg"))


### PR DESCRIPTION
# Description

Added a feature to see the list of mentors on suborgs. After a mentor is successfully registered, the user_id of the mentor appears on the suborg application list page.

Fixes #429 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

I created a suborg from student-2 and accepted with admin. After that I added mentors and I registered mentors. After successful registration, they appear on the suborg application page.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have not added a commit to any .db files as part of my pull request
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
