### PR TITLE
show suborgs of users on user list

### DIFF
--- a/gsoc/admin.py
+++ b/gsoc/admin.py
@@ -348,16 +348,11 @@ class HiddenUserProfileAdmin(admin.ModelAdmin):
         "user",
         "email",
         "gsoc_year",
-        "suborg_full_name",
-        "proposal_confirmed",
-        "hidden",
-        "reminder_disabled",
-        "current_blog_count",
         "role",
-        "gsoc_invited",
+        "github_handle",
     )
     list_filter = \
-        ("hidden", "suborg_full_name", "reminder_disabled", "role", "gsoc_invited", "gsoc_year")
+        ("role", "gsoc_invited", "suborg_full_name", "gsoc_year")
     readonly_fields = (
         "user",
         "role",

--- a/gsoc/admin.py
+++ b/gsoc/admin.py
@@ -356,7 +356,8 @@ class HiddenUserProfileAdmin(admin.ModelAdmin):
         "role",
         "gsoc_invited",
     )
-    list_filter = ("hidden", "suborg_full_name", "reminder_disabled", "role", "gsoc_invited", "gsoc_year")
+    list_filter = \
+        ("hidden", "suborg_full_name", "reminder_disabled", "role", "gsoc_invited", "gsoc_year")
     readonly_fields = (
         "user",
         "role",

--- a/gsoc/admin.py
+++ b/gsoc/admin.py
@@ -356,7 +356,7 @@ class HiddenUserProfileAdmin(admin.ModelAdmin):
         "role",
         "gsoc_invited",
     )
-    list_filter = ("hidden", "reminder_disabled", "role", "gsoc_invited")
+    list_filter = ("hidden", "suborg_full_name", "reminder_disabled", "role", "gsoc_invited", "gsoc_year")
     readonly_fields = (
         "user",
         "role",

--- a/gsoc/admin.py
+++ b/gsoc/admin.py
@@ -351,8 +351,7 @@ class HiddenUserProfileAdmin(admin.ModelAdmin):
         "role",
         "github_handle",
     )
-    list_filter = \
-        ("role", "gsoc_invited", "suborg_full_name", "gsoc_year")
+    list_filter = ("role", "gsoc_invited", "suborg_full_name", "gsoc_year")
     readonly_fields = (
         "user",
         "role",

--- a/gsoc/cms_toolbars.py
+++ b/gsoc/cms_toolbars.py
@@ -36,7 +36,7 @@ def add_admin_menu(self):
         if user and user.is_superuser:
             # Users button
             self._admin_menu.add_sideframe_item(
-                _("Users"), url="admin/gsoc/userprofile"
+                _("User Profiles"), url="admin/gsoc/userprofile"
             )
 
         # sites menu

--- a/gsoc/cms_toolbars.py
+++ b/gsoc/cms_toolbars.py
@@ -30,8 +30,14 @@ def add_admin_menu(self):
         self._admin_menu = self.toolbar.get_or_create_menu(
             ADMIN_MENU_IDENTIFIER, self.current_site.name
         )
-        # Users button
-        self.add_users_button(self._admin_menu)
+
+        user = getattr(self.request, "user", None)
+
+        if user and user.is_superuser:
+            # Users button
+            self._admin_menu.add_sideframe_item(
+                _("Users"), url="admin/gsoc/userprofile"
+            )
 
         # sites menu
         sites_queryset = Site.objects.order_by("name")
@@ -48,8 +54,6 @@ def add_admin_menu(self):
                     url="http://%s" % site.domain,
                     active=site.pk == self.current_site.pk,
                 )
-
-        user = getattr(self.request, "user", None)
 
         # admin
         self._admin_menu.add_sideframe_item(


### PR DESCRIPTION
# Description

Updated default Users menu item to show list of users including their suborgs name

Fixes #367 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tested manually

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have not added a commit to any .db files as part of my pull request
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
