### PR TITLE
Update blogging requirements, student vs contributor language

### DIFF
--- a/gsoc/templates/email/first_post_blog_reminder_student.html
+++ b/gsoc/templates/email/first_post_blog_reminder_student.html
@@ -1,8 +1,8 @@
 The due date for the weekly blog ({{ due_date }}) has passed and you have not made a blog post yet.<br />
 <br />
-It looks like you have {{ current_blog_count }} blog post(s) pending. Make sure to get your posts in as soon as possible. <br />
+It looks like you have {{ current_blog_count - 1 }} blog post(s) pending. Make sure to get your posts in as soon as possible. <br />
 <br />
-<b>Blogging is required for Python Software Foundation students, since that's how the org admin teams ensure that students are still active. </b><br />
+<b>Blogging is recommended for Python Software Foundation GSoC contributors, since that's how the org admin teams ensure that contributors are still active. </b><br />
 <br />
 If you have any issues please DO NOT reply to this email, and email <a href = "mailto: gsoc-admins@python.org">gsoc-admins@python.org</a><br />
 <br />

--- a/gsoc/templates/email/invite.html
+++ b/gsoc/templates/email/invite.html
@@ -5,9 +5,9 @@ You have been invitied to be a {% if role == 1 %}Suborg Admin{% elif role == 2 %
 <br />
 You will need to register using the link below to be invited by Google.<br />
 {% else %}
-<p>Students are required to post something every week.  We do this for two reasons: firstly, to help the Python org admins tell that you're active and still on track, and secondly to help the wider Python community understand what our students are doing.
+<p>GSoC contributors are encouraged to post something every week.  We do this for two reasons: firstly, to help the Python org admins tell that you're active and still on track, and secondly to help the wider Python community understand what our GSoC contributors are doing.
 
-<p>Python requires two types of posts on alternating weeks.  One is a weekly check-in post that answers the three questions below. Each answer expected to be very short (each answer is typically under 100 words).  This short post addresses the first goal by giving a way for org admins to tell if a student is active and on track or needs additional assistance.
+<p>Python recommends that you answer the following questions in your post:
 
 <br />
 &emsp;1. What did you do this week?<br />
@@ -15,11 +15,11 @@ You will need to register using the link below to be invited by Google.<br />
 &emsp;3. Did you get stuck anywhere?<br />
 <br />
 
-The second post is a blog post, where students will be required to go into some detail on what they are working on, what they struggle with, and what solutions they have found. There is no formal structure to this and every student is welcome to use their own style but the above three questions should be answered in the blog post at some point. This longer post addresses the second goal, helping the wider python community understand what our students are doing.<br />
-<br />
+<p>These answers can be very short or you can go into longer detail about the project.  Longer posts help the wider Python community understand what work is being done as part of Google Summer of Code, shorter posts can function as simple status reports.
+
 <br />
 {% endif %}
-Blogs and suborgs are handled by our new GSoC blogging platform, so please report any bugs, issues, or suggestions to <a href = "https://github.com/python-gsoc/python-blogs/issues">https://github.com/python-gsoc/python-blogs/issues</a> or email <a href = "mailto: gsoc-admins@python.org">gsoc-admins@python.org</a> <br />
+Blogs and suborgs are handled by our GSoC blogging platform, so please report any bugs, issues, or suggestions to <a href = "https://github.com/python-gsoc/python-blogs/issues">https://github.com/python-gsoc/python-blogs/issues</a> or email <a href = "mailto: gsoc-admins@python.org">gsoc-admins@python.org</a> <br />
 <br />
 To register you will need to go to <a href="{{ register_link }}">{{ register_link }}</a> <br />
 <br />

--- a/gsoc/templates/email/post_blog_reminder_mentors.html
+++ b/gsoc/templates/email/post_blog_reminder_mentors.html
@@ -1,8 +1,8 @@
 The due date for the weekly blog for {{ student_username }} ({{ student_email }}) with {{ suborg_name }} has passed and they have not made a blog post as of the due date on {{ due_date }}.<br />
 <br />
-It looks like they have {{ current_blog_count }} blog post(s) pending. Make sure to get your student to post as soon as possible. <br />
+It looks like they have {{ current_blog_count - 1}} blog post(s) pending. Make sure to get your GSoC contributor to post as soon as possible. <br />
 <br />
-<b>Blogging is required for Python Software Foundation students, since that's how the org admin teams ensure that students are still active.  Inactive students will be given failing grades.<br /></b>
+<b>Blogging is recommended for Python Software Foundation GSoC contributors, since that's how the org admin teams ensure that contributors are still active.  Inactive contributors will be given failing grades.<br /></b>
 <br />
 If you have any issues please DO NOT reply to this email, and email <a href = "mailto: gsoc-admins@python.org">gsoc-admins@python.org</a><br />
 <br />

--- a/gsoc/templates/email/pre_blog_reminder.html
+++ b/gsoc/templates/email/pre_blog_reminder.html
@@ -1,7 +1,7 @@
-This is a reminder for the {% if role == 0 %}Blog Post{% else %}Weekly Check-In{% endif %} required on {{ due_date }}. <br />
+This is a reminder for the Blog Post recommended on {{ due_date }}. <br />
 <br />
 {% if current_blog_count > 1 %}
-It looks like you have {{ current_blog_count }} post(s) pending. Make sure to get your posts in as soon as possible. <br /><br />
+It looks like you have {{ current_blog_count - 1 }} post(s) pending. Make sure to get your posts in as soon as possible.  If you're not working this week and want to stop getting reminders, it is fine to post a post saying that you are out this week.<br /><br />
 {% endif %}
 If you have any issues please DO NOT reply to this email, and email <a href = "mailto: gsoc-admins@python.org">gsoc-admins@python.org</a><br />
 <br />

--- a/gsoc/templates/email/second_post_blog_reminder_student.html
+++ b/gsoc/templates/email/second_post_blog_reminder_student.html
@@ -1,8 +1,8 @@
 The due date for the weekly blog ({{ due_date }}) has passed and you have not made a blog post yet.<br />
 <br />
-It looks like you have {{ current_blog_count }} blog post(s) pending. Make sure to get your posts in as soon as possible. <br />
+It looks like you have {{ current_blog_count -1 }} blog post(s) pending. Make sure to get your posts in as soon as possible. <br />
 <br />
-<b>Blogging is required for Python Software Foundation students, since that's how the org admin teams ensure that students are still active.  Inactive students will be given failing grades.</b><br />
+<b>Blogging is recommended for Python Software Foundation GSoC Contributors, since that's how the org admin teams ensure that contributors are still active.  Inactive contributors will be given failing grades.</b><br />
 <br />
 If you have any issues please DO NOT reply to this email, and email <a href = "mailto: gsoc-admins@python.org">gsoc-admins@python.org</a><br />
 <br />


### PR DESCRIPTION
Blogging email reminder updates:
1. Changed language to reflect that blogging is recommended but not required this year
2. Changed language from "student" to "GSoC contributor" to be in line with google's changes
3. Changed from having long and short posts to just one status update post (but mention that longer posts are encouraged still)
4. Changed the number of pending posts to be -1 because a lot of people found that confusing (if you missed one post it would always say you were behind by two)