### PR TITLE
Allow CSS properties on bleach.clean

### DIFF
--- a/gsoc/models.py
+++ b/gsoc/models.py
@@ -5,6 +5,7 @@ import uuid
 import json
 import bleach
 from urllib.parse import urljoin
+from bleach.css_sanitizer import CSSSanitizer
 
 from bs4 import BeautifulSoup
 from django.db.models.deletion import PROTECT
@@ -166,12 +167,13 @@ Article.add_to_class("get_root_comments", get_root_comments)
 
 
 def save(self, *args, **kwargs):
+    css_sanitizer = CSSSanitizer(allowed_css_properties=settings.BLEACH_ALLOWED_STYLES)
     tags = settings.BLEACH_ALLOWED_TAGS
     attrs = bleach.sanitizer.ALLOWED_ATTRIBUTES
     attrs.update(settings.BLEACH_ALLOWED_ATTRS)
     styles = settings.BLEACH_ALLOWED_STYLES
     self.lead_in = bleach.clean(
-        self.lead_in, tags=tags, attributes=attrs
+        self.lead_in, tags=tags, attributes=attrs, css_sanitizer=css_sanitizer
     )
     soup = BeautifulSoup(self.lead_in, "html5lib")
     for iframe_tag in soup.find_all("iframe"):

--- a/gsoc/models.py
+++ b/gsoc/models.py
@@ -171,7 +171,6 @@ def save(self, *args, **kwargs):
     tags = settings.BLEACH_ALLOWED_TAGS
     attrs = bleach.sanitizer.ALLOWED_ATTRIBUTES
     attrs.update(settings.BLEACH_ALLOWED_ATTRS)
-    styles = settings.BLEACH_ALLOWED_STYLES
     self.lead_in = bleach.clean(
         self.lead_in, tags=tags, attributes=attrs, css_sanitizer=css_sanitizer
     )


### PR DESCRIPTION
# Description
Currently, the CSS attributes are being cleaned by the bleach.clean method. This Pull Request adds support to allow CSS properties on the pages instead of removing them.

Fixes #530 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
By creating blog post with different image alignments

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have not added a commit to any .db files as part of my pull request
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
