### PR TITLE
Update cms_toolbars.py

### DIFF
--- a/aldryn_people/cms_toolbars.py
+++ b/aldryn_people/cms_toolbars.py
@@ -44,10 +44,12 @@ def get_obj_from_request(model, request,
         return None
 
 
-def get_admin_url(action, action_args=[], **url_args):
+def get_admin_url(action, action_args=None, **url_args):
     """
     Convenience method for constructing admin-urls with GET parameters.
     """
+    if action_args == None: 
+        action_args = [] 
     base_url = admin_reverse(action, args=action_args)
     # Converts [{key: value}, …] => ["key=value", …]
     url_arg_list = sorted(iteritems(url_args))


### PR DESCRIPTION
# Description

Currently, the default argument list 'action_args' accumulates the data from previous executions. This pull request makes sure that the default argument always has an empty list as intended.

Fixes #535 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Calling the function again and testing it shows that the previous execution data isn't accumulated in the default 
parameter

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have not added a commit to any .db files as part of my pull request
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
